### PR TITLE
fix: link to Manual in footer section is broken

### DIFF
--- a/foundation/templates/includes/footer/footer.html
+++ b/foundation/templates/includes/footer/footer.html
@@ -98,7 +98,7 @@
 					<li class="mb-2">
 						<a class="text-muted indicator blue" href="/releases/version-11">Version 11</a>
 					<li class="mb-2">
-						<a class="text-muted" href="/docs/user/manual">Manual</a>
+						<a class="text-muted" href="https://erpnext.com/docs/user/manual">Manual</a>
 					</li>
 					<li class="mb-2">
 						<a class="text-muted" href="https://www.youtube.com/c/erpnext" target="_blank" >Video Tutorials</a>


### PR DESCRIPTION
https://discuss.erpnext.com/t/erpnext-org-link-to-manuals-under-grey-documentation-footer-section-is-broken/53179